### PR TITLE
Make postgresql container data persistent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ commons-server
 
 # python bytecode
 *.pyc
+
+# Postgresql persistent data
+pg-data/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build: "./docker/diagnosis-key-pg"
     ports:
       - "5434:5432"
+    volumes:
+      - "./pg-data/:/data/"
   commons-server:
     build: "./docker/commons-server"
     depends_on:

--- a/docker/diagnosis-key-pg/Dockerfile
+++ b/docker/diagnosis-key-pg/Dockerfile
@@ -1,46 +1,43 @@
-FROM ubuntu:19.10
+FROM postgres:11
 
-ENV DEBIAN_FRONTEND=noninteractive
-
+# Silence debconf TERM messages
+RUN echo "debconf debconf/frontend select Noninteractive" | debconf-set-selections
 RUN apt-get update && apt-get install -y \
-   curl \
-   gnupg \
-   software-properties-common
+      postgresql-11-postgis-3 \
+      postgresql-plpython3-11 \
+      python3-dev \
+      python3-pip \
+      # Utilities
+      software-properties-common \
+      apt-transport-https \
+      ca-certificates \
+      gnupg \
+      wget
 
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -c -s)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list
-RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-RUN add-apt-repository ppa:timescale/timescaledb-ppa
+# Setup postgresql data dir and config
+RUN mkdir /data/
+RUN cat /usr/share/postgresql/postgresql.conf.sample > /data/postgresql.conf
 
-RUN apt-get update && apt-get install -y \
-   postgresql-11 \
-   timescaledb-postgresql-11 \
-   postgresql-11-postgis-3 \
-   postgresql-plpython3-11 \
-   python3-dev \
-   python3-pip
+# Add timescale
+RUN sh -c "echo 'deb https://packagecloud.io/timescale/timescaledb/debian/ `lsb_release -c -s` main' > /etc/apt/sources.list.d/timescaledb.list"
+RUN wget --quiet -O - https://packagecloud.io/timescale/timescaledb/gpgkey | apt-key add -
+RUN apt-get update && apt-get install -y timescaledb-postgresql-11
+RUN timescaledb-tune --quiet --yes --conf-path=/data/postgresql.conf
 
 RUN python3 -m pip install openlocationcode
 
-RUN timescaledb-tune --quiet --yes
-RUN echo "host all  all    0.0.0.0/0  password" >> /etc/postgresql/11/main/pg_hba.conf
-RUN echo "listen_addresses='*'" >> /etc/postgresql/11/main/postgresql.conf
+# Add initialization scripts
+ADD setup.sql /docker-entrypoint-initdb.d/
 
-# ADD setup.sql /opt/setup.sql
-ADD setup.sql /opt/setup.sql
-
-USER postgres
-RUN /etc/init.d/postgresql start &&\
-    psql --command "CREATE USER covid19 WITH SUPERUSER PASSWORD 'covid19databasepassword';" &&\
-    createdb -O covid19 covid19 &&\
-    # psql -d covid19 --command "CREATE EXTENSION postgis;" &&\
-    # psql -d covid19 --command "CREATE EXTENSION plpython3u;" &&\
-    # psql -d covid19 --command "CREATE EXTENSION timescaledb CASCADE;" &&\
-    psql -d covid19 --command "\i opt/setup.sql"
-    # psql -d covid19 --command "CREATE EXTENSION hstore;" &&\
-    # psql -d covid19 --command "CREATE EXTENSION hstore_plpython3u;" &&\
 RUN pg_lsclusters
 
-# Expose the PostgreSQL port
-EXPOSE 5432
+ENV DEBIAN_FRONTEND=noninteractive
+# PostgreSQL ENV variables
+ENV POSTGRES_USER=covid19
+ENV POSTGRES_PASSWORD=covid19databasepassword
+ENV POSTGRES_HOST_AUTH_METHOD=password
+ENV POSTGRES_DB=covid19
+ENV PGDATA=/data/
 
-CMD ["/usr/lib/postgresql/11/bin/postgres", "-D", "/var/lib/postgresql/11/main", "-c", "config_file=/etc/postgresql/11/main/postgresql.conf"]
+VOLUME /data
+EXPOSE 5432

--- a/docker/diagnosis-key-pg/Dockerfile
+++ b/docker/diagnosis-key-pg/Dockerfile
@@ -31,7 +31,6 @@ ADD setup.sql /docker-entrypoint-initdb.d/
 
 RUN pg_lsclusters
 
-ENV DEBIAN_FRONTEND=noninteractive
 # PostgreSQL ENV variables
 ENV POSTGRES_USER=covid19
 ENV POSTGRES_PASSWORD=covid19databasepassword


### PR DESCRIPTION
- moved from ubuntu base image to postgresql base image (based on debian) for simpler setup and volume bind mount permission management
- will persist postgresql data to `./pg-data/`