### PR TITLE
Add ansible roles and playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 
 ## Setup
+```
+docker-compose build
+docker-compose up
+```
+
+### Building `commons-server` From Source
+Docker will take care of building the binary, but you can also do it yourself.
 
 0. Make sure to initialize the `googleapis` submodule if you are editing the .proto definitions
     ```
@@ -11,6 +18,8 @@
 1. Install dependencies:
     ```
     sudo apt install libprotobuf-dev  # or equivalent on other systems
+    sudo apt install protobuf-compiler
+    pip3 install grpcio-tools
     go install \
         github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway \
         github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger \
@@ -21,12 +30,6 @@
     ```
     make proto # if necessary
     make commons-server
-    ```
-
-3. Build Docker files and deploy. **Note: you will need to rebuild the commons-server using `make` before running `docker-compose`; the Dockerfile uses the prebuilt binary**
-    ```
-    docker-compose build
-    docker-compose up
     ```
 
 ## Simulation

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+stdout_callback = yaml

--- a/ansible/covidcommons/defaults/main.yml
+++ b/ansible/covidcommons/defaults/main.yml
@@ -1,0 +1,1 @@
+covidcommons_path: "~/covidcommons"

--- a/ansible/covidcommons/meta/main.yml
+++ b/ansible/covidcommons/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - role: docker

--- a/ansible/covidcommons/tasks/main.yml
+++ b/ansible/covidcommons/tasks/main.yml
@@ -1,0 +1,11 @@
+- name: Clone the coviddb repo
+  git:
+    repo: "https://github.com/covista/commons"
+    dest: "{{ covidcommons_path }}"
+    update: no
+
+- name: Run docker compose
+  become: yes
+  docker_compose:
+    state: present
+    project_src: "{{ covidcommons_path }}"

--- a/ansible/docker/tasks/main.yml
+++ b/ansible/docker/tasks/main.yml
@@ -1,0 +1,19 @@
+- name: Check required packages
+  become: yes
+  package:
+    name: [docker.io, python3, python3-pip]
+    state: present
+    update_cache: yes
+    cache_valid_time: 3600
+
+- name: Install docker-compose for python
+  become: yes
+  pip:
+    name: docker-compose
+
+- name: Ensure docker service is started and enabled
+  become: yes
+  service:
+    name: docker
+    state: started
+    enabled: yes

--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -1,0 +1,4 @@
+- name: Master playbook
+  hosts: all:!localhost
+  roles:
+    - covidcommons

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,9 @@ services:
     ports:
       - "5434:5432"
   commons-server:
-    build: "./docker/commons-server"
+    build:
+      context: .
+      dockerfile: "./docker/commons-server/Dockerfile"
     depends_on:
       - "diagnosis-key-pg"
     environment:

--- a/docker/commons-server/Dockerfile
+++ b/docker/commons-server/Dockerfile
@@ -1,5 +1,26 @@
+# Build image
+FROM golang AS builder
+
+WORKDIR /app
+
+COPY . .
+
+RUN go install \
+      github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway \
+      github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger \
+      github.com/golang/protobuf/protoc-gen-go
+
+RUN apt update && apt install -y \
+      protobuf-compiler \
+      python3-pip
+
+RUN pip3 install grpcio-tools
+
+RUN make commons-server
+
+# Runtime image
 FROM ubuntu:19.10
 
-ADD commons-server /bin/commons-server
+COPY --from=builder /app/commons-server .
 
-CMD ["commons-server"]
+CMD ["./commons-server"]


### PR DESCRIPTION
- add ansible roles and playbook in `ansible` folder
  - run inside the `ansible` folder with `ansible-playbook main.yml` with the proper `hosts` file or `ansible-playbook -i USER@REMOTE, main.yml`
- add multistage docker build for the `commons-server` binary